### PR TITLE
Fix typo in standard MLP decoder class

### DIFF
--- a/EVE/VAE_decoder.py
+++ b/EVE/VAE_decoder.py
@@ -256,7 +256,7 @@ class VAE_Standard_MLP_decoder(nn.Module):
             self.temperature_scaler = nn.Parameter(torch.ones(1))
 
     def forward(self, z):
-        batch_size = x.shape[0]
+        batch_size = z.shape[0]
         if self.dropout_proba > 0.0:
             x = self.dropout_layer(z)
         else:

--- a/EVE/VAE_decoder.py
+++ b/EVE/VAE_decoder.py
@@ -170,8 +170,7 @@ class VAE_Standard_MLP_decoder(nn.Module):
     """
     Standard MLP decoder class for the VAE model.
     """
-    def __init__(self, seq_len, alphabet_size, hidden_layers_sizes, z_dim, first_hidden_nonlinearity, last_hidden_nonlinearity, dropout_proba,
-                 convolve_output, convolution_depth, include_temperature_scaler, include_sparsity, num_tiles_sparsity):
+    def __init__(self, params):
         """
         Required input parameters:
         - seq_len: (Int) Sequence length of sequence alignment

--- a/EVE/VAE_model.py
+++ b/EVE/VAE_model.py
@@ -38,6 +38,9 @@ class VAE_model(nn.Module):
         self.alphabet_size = data.alphabet_size
         self.Neff = data.Neff
 
+        self.encoder_parameters=encoder_parameters
+        self.decoder_parameters=decoder_parameters
+
         encoder_parameters['seq_len'] = self.seq_len
         encoder_parameters['alphabet_size'] = self.alphabet_size
         decoder_parameters['seq_len'] = self.seq_len
@@ -233,8 +236,8 @@ class VAE_model(nn.Module):
 
             if training_step % training_parameters['save_model_params_freq']==0:
                 self.save(model_checkpoint=training_parameters['model_checkpoint_location']+os.sep+self.model_name+"_step_"+str(training_step),
-                            encoder_parameters=encoder_parameters,
-                            decoder_parameters=decoder_parameters,
+                            encoder_parameters=self.encoder_parameters,
+                            decoder_parameters=self.decoder_parameters,
                             training_parameters=training_parameters)
             
             if training_parameters['use_validation_set'] and training_step % training_parameters['validation_freq'] == 0:

--- a/EVE/VAE_model.py
+++ b/EVE/VAE_model.py
@@ -254,8 +254,8 @@ class VAE_model(nn.Module):
                     best_val_loss = val_neg_ELBO
                     best_model_step_index = training_step
                     self.save(model_checkpoint=training_parameters['model_checkpoint_location']+os.sep+self.model_name+"_best",
-                                encoder_parameters=encoder_parameters,
-                                decoder_parameters=decoder_parameters,
+                                encoder_parameters=self.encoder_parameters,
+                                decoder_parameters=self.decoder_parameters,
                                 training_parameters=training_parameters)
                 self.train()
     

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Evolutionary model of Variant Effects (EVE)
 
-Please note that we have migrated the official repo to the following address: https://github.com/OATML-Markslab/EVE.
+This is the official code repository for the paper "Disease variant prediction with deep generative models of evolutionary data" (https://www.nature.com/articles/s41586-021-04043-8). This project is a joint collaboration between the Marks lab (https://www.deboramarkslab.com/) and the OATML group (https://oatml.cs.ox.ac.uk/).
 
 ## Overview
 EVE is a set of protein-specific models providing for any single amino acid mutation of interest a score reflecting the propensity of the resulting protein to be pathogenic. For each protein family, a Bayesian VAE learns a distribution over amino acid sequences from evolutionary data. It enables the computation of an evolutionary index for each mutant, which approximates the log-likelihood ratio of the mutant vs the wild type. A global-local mixture of Gaussian Mixture Models separates variants into benign and pathogenic clusters based on that index. The EVE scores reflect probabilistic assignments to the pathogenic cluster.
@@ -67,7 +67,7 @@ If you use this code, please cite the following paper:
   year={2021}
 }
 ```
-<<<<<<< HEAD
-Link: https://www.nature.com/articles/s41586-021-04043-8
-=======
->>>>>>> bug_fix_intermediate_saving
+
+Links: 
+- Paper: https://www.nature.com/articles/s41586-021-04043-8
+- Pre-print: https://www.biorxiv.org/content/10.1101/2020.12.21.423785v1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-
+[![DOI](https://zenodo.org/badge/402479185.svg)](https://zenodo.org/badge/latestdoi/402479185)
 
 # Evolutionary model of Variant Effects (EVE)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ MSAs and ClinVar labels are provided for 4 proteins (P53, PTEN, RASH and SCN5A) 
 The only data required to train EVE models and obtain EVE scores from scratch are the multiple sequence alignments (MSAs) for the corresponding proteins. 
 
 ### MSA creation
-We built multiple sequence alignments for each protein family by performing five search iterations of the profile HMM homology search tool Jackhmmer against the UniRef100 database of non-redundant protein sequences (downloaded on April 20th 2020). Please refer to the supplementary notes of the EVE paper (section 3.1.1) for a detailed description of the MSA creation process. 
+
+We build multiple sequence alignments for each protein family by performing five search iterations of the profile HMM homology search tool Jackhmmer against the UniRef100 database of non-redundant protein sequences (downloaded on April 20th 2020). We retrieve sequences that align to at least 50% of the target protein sequence, and columns with at least 70% residue occupancy. This is done using [EVcouplings](https://github.com/debbiemarkslab/EVcouplings/tree/80d30b3d2568ae3327f973346be73cdcd41f678b). 
+
+We explore a range of bit score thresholds, using 0.3 bits per residue as a reference, and select the best possible multiple sequence alignment based on the criteria of maximal coverage of the target protein sequence and sufficient, but not excessive, number of sequences in the alignment (the latter implying an alignment that is too lenient). Specifically, we prioritize alignments with coverage L<sub>cov</sub> ≥ 0.8L, where L is the length of the target protein sequence, and with a total number of sequences N such that 100,000 ≥ N ≥ 10L. If these requirements cannot be met, we sequentially relax them down to L<sub>cov</sub> ≥ 0.7L and N ≤ 200,000. These criteria are met for 97% of alignments. For the remaining 3%, we drop the coverage constraint entirely. Following this procedure, we have so far obtained a set of 3,219 clinically relevant proteins with corresponding evolutionary training data. While we expect the performance of our model to depend on the quality of the multiple sequence alignments, we do not find strong correlation between performance and alignment depth N/L<sub>cov</sub>.
+
 Our github repo provides the MSAs for 4 proteins: P53, PTEN, RASH & SCN5A (see data/MSA). MSAs for all proteins may be accessed on our website (https://evemodel.org/).
 
 ### MSA pre-processing

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![DOI](https://zenodo.org/badge/328127288.svg)](https://zenodo.org/badge/latestdoi/328127288)
+
 
 # Evolutionary model of Variant Effects (EVE)
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,12 @@ This project is available under the MIT license.
 
 ## Reference
 If you use this code, please cite the following paper:
+```bibtex
+@article{Frazer2021DiseaseVP,
+  title={Disease variant prediction with deep generative models of evolutionary data.},
+  author={Jonathan Frazer and Pascal Notin and Mafalda Dias and Aidan Gomez and Joseph K Min and Kelly P. Brock and Yarin Gal and Debora S. Marks},
+  journal={Nature},
+  year={2021}
+}
 ```
-Large-scale clinical interpretation of genetic variants using evolutionary data and deep learning
-Jonathan Frazer, Pascal Notin, Mafalda Dias, Aidan Gomez, Kelly Brock, Yarin Gal, Debora S. Marks
-bioRxiv 2020.12.21.423785
-doi: https://doi.org/10.1101/2020.12.21.423785
-```
+Link: https://www.nature.com/articles/s41586-021-04043-8

--- a/train_VAE.py
+++ b/train_VAE.py
@@ -17,6 +17,7 @@ if __name__=='__main__':
     parser.add_argument('--model_name_suffix', default='Jan1', type=str, help='model checkpoint name will be the protein name followed by this suffix')
     parser.add_argument('--model_parameters_location', type=str, help='Location of VAE model parameters')
     parser.add_argument('--training_logs_location', type=str, help='Location of VAE model parameters')
+    parser.add_argument('--seed', type=int, default=42, help='Random seed')
     args = parser.parse_args()
 
     mapping_file = pd.read_csv(args.MSA_list)
@@ -51,7 +52,7 @@ if __name__=='__main__':
                     data=data,
                     encoder_parameters=model_params["encoder_parameters"],
                     decoder_parameters=model_params["decoder_parameters"],
-                    random_seed=42
+                    random_seed=args.seed
     )
     model = model.to(model.device)
 


### PR DESCRIPTION
Thanks for publishing this code! I noticed a slight error when calling the StandardMLPDecoder class - it should be initialised with the dict "params" rather than with individual parameters. I've fixed this to allow comparison of the two classes.